### PR TITLE
update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-requests==2.26.0
-eip712==0.1.0
-eth_account==0.5.5
-hexbytes==0.2.2
-web3==5.23.1
-python-dotenv==0.19.2
+requests==2.31.0
+eip712==0.2.1
+eth_account==0.9.0
+hexbytes==0.3.1
+web3==6.9.0
+python-dotenv==1.0.0

--- a/src/domains.py
+++ b/src/domains.py
@@ -6,7 +6,7 @@ load_dotenv()
 private_key = os.getenv("PRIVATE_KEY")
 network = os.getenv("NETWORK")
 
-base_url = f"https://protocol-{network}.gnosis.io/api/v1/"
+base_url = f"https://api.cow.fi/{network}/api/v1/"
 name = "Gnosis Protocol"
 version = "v2"
 verifying_contract = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"


### PR DESCRIPTION
Partially helps with #4 

It appears the order placement API now rejects orders with malformed appdata. We will need to compute the correct app id before we can get this running again.

cc @koeppelmann


This is also an outdated project because, for example, the fee endpoint no longer exists and has been replaced by the quote endpoint. I could probably update this sometime soon.

