### PR TITLE
EIP712 requires an older version of eth_account

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.31.0
 eip712==0.2.1
-eth_account==0.9.0
+eth_account==0.8.0
 hexbytes==0.3.1
 web3==6.9.0
 python-dotenv==1.0.0


### PR DESCRIPTION
eip712 requires eth_account < 0.9.0